### PR TITLE
Update airbnb dependency to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ things we do not plan to prescribe to.
 
 ### With React Style
 
-1. `npm install --save-dev eslint-config-exchange-solutions babel-eslint eslint-plugin-react`
+1. `npm install --save-dev eslint-config-exchange-solutions babel-eslint eslint-plugin-react eslint-plugin-import eslint-plugin-jsx-a11y`
 2. add `"extends": "exchange-solutions"` to your .eslintrc
 
 ### Without React Style

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   },
   "homepage": "https://github.com/TWExchangeSolutions/eslint-config-exchange-solutions#readme",
   "dependencies": {
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
-    "eslint-plugin-react": "^5.0.1"
+    "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-import": "^1.8.1",
+    "eslint-plugin-jsx-a11y": "^1.4.2",
+    "eslint-plugin-react": "^5.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
Having the latest version of eslint-plugin-react@5.1.1 fails to meet the peer dependency set by airbnb@^7.0.0. 

This PR updates the airbnb eslint config dependency here to the latest they have available on npm and includes the two additional dependencies (eslint-plugin-import@^1.8.1, eslint-plugin-jsx-a11y@^1.4.2) as dependencies.

I've also updated the README to include the added dependencies in the install script.